### PR TITLE
Fix command where abandoned is not a boolean

### DIFF
--- a/src/Commands/CheckDependencyVersions.php
+++ b/src/Commands/CheckDependencyVersions.php
@@ -39,7 +39,7 @@ class CheckDependencyVersions extends Command
                 'status' => $package->{'latest-status'},
                 'direct_dependency' => $package->{'direct-dependency'},
                 'description' => $package->description,
-                'abandoned' => $package->abandoned,
+                'abandoned' => is_bool($package->abandoned) ? $package->abandoned : true,
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);


### PR DESCRIPTION
I ran into an error when running the versions command that a package owner had set abandoned to a string. This caused the database insert to fail because the types failed. The PR assumes that if the value of abandoned is not a boolean, then it must be true. In the event of false positives where people have mistakenly set abandoned to a string, it's better to report that than assume that the package is not abandoned. 

Package in question was: https://github.com/ryangjchandler/blade-tabler-icons/blob/main/composer.json