### PR TITLE
Add authorization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This package provides a comprehensive system information page and widgets for Fi
 - 📈 **System Stats Widget** - Display Laravel and Filament versions
 - ⚙️ **System Info Widget** - Show environment, PHP version, and Laravel version
 - 🎨 **Customizable Navigation** - Configure navigation group, icon, label, and sort order
+- 🔒 **Authorization Control** – Define who can access the page using a boolean or a closure
 
 ## Installation
 
@@ -111,12 +112,36 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+### Controlling Access to the Page
+
+Access to the System Info page can be restricted through the `authorize` method provided by the plugin.
+
+This method accepts either a simple boolean or a closure, and must resolve to true when the current user should be allowed to view the page.
+
+```php
+use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ... other configuration
+        ->plugin(
+            FilamentSystemVersionsPlugin::make()
+                // Example with Spatie Roles / Filament Shield
+                ->authorize(fn () => auth()->user()?->hasRole('super_admin'))
+                // Example with is_admin column on users table
+                ->authorize(fn () => auth()->user()?->is_admin)
+        );
+}
+```
+
 #### Available Configuration Methods
 
 - `navigationLabel(string $label)` - Set the navigation menu label (default: 'System Versions')
 - `navigationGroup(string $group)` - Set the navigation group (default: 'Settings')
 - `navigationIcon(string $icon)` - Set the navigation icon (default: 'heroicon-o-document-text')
 - `navigationSort(int $sort)` - Set the navigation sort order (default: 99999)
+- `authorize(bool | Closure)` - Define whether the current user is allowed to access the page. Accepts either a `bool` (`true` or `false`) or a `Closure` that returns a boolean (default: true).
 
 ### Dependency Versions Command
 

--- a/src/Filament/Pages/SystemVersions.php
+++ b/src/Filament/Pages/SystemVersions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cmsmaxinc\FilamentSystemVersions\Filament\Pages;
 
+use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;
 use Filament\Pages\Page;
 use UnitEnum;
 
@@ -18,4 +19,10 @@ class SystemVersions extends Page
     protected static ?string $navigationLabel = 'System Versions';
 
     protected static ?int $navigationSort = 99999;
+
+
+    public static function canAccess(): bool
+    {
+        return FilamentSystemVersionsPlugin::get()->isAuthorized();
+    }
 }

--- a/src/FilamentSystemVersionsPlugin.php
+++ b/src/FilamentSystemVersionsPlugin.php
@@ -2,13 +2,19 @@
 
 namespace Cmsmaxinc\FilamentSystemVersions;
 
+use Closure;
 use Cmsmaxinc\FilamentSystemVersions\Filament\Pages\SystemVersions;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
+use Filament\Support\Concerns\EvaluatesClosures;
 use UnitEnum;
 
 class FilamentSystemVersionsPlugin implements Plugin
 {
+    use EvaluatesClosures;
+
+    protected bool | Closure $authorizeUsing = true;
+
     protected ?string $navigationGroup = null;
 
     protected string | \BackedEnum | null $navigationIcon = null;
@@ -51,6 +57,18 @@ class FilamentSystemVersionsPlugin implements Plugin
         $navigationSort = $reflection->getProperty('navigationSort');
         $navigationSort->setAccessible(true);
         $navigationSort->setValue(null, $this->getNavigationSort());
+    }
+
+    public function authorize(bool | Closure $callback = true): static
+    {
+        $this->authorizeUsing = $callback;
+
+        return $this;
+    }
+
+    public function isAuthorized(): bool
+    {
+        return $this->evaluate($this->authorizeUsing) === true;
     }
 
     public function navigationGroup(string | UnitEnum | null $group): static

--- a/src/FilamentSystemVersionsPlugin.php
+++ b/src/FilamentSystemVersionsPlugin.php
@@ -68,7 +68,7 @@ class FilamentSystemVersionsPlugin implements Plugin
 
     public function isAuthorized(): bool
     {
-        return $this->evaluate($this->authorizeUsing) === true;
+        return $this->evaluate($this->authorizeUsing);
     }
 
     public function navigationGroup(string | UnitEnum | null $group): static


### PR DESCRIPTION
Added `authorize(bool | Closure)` method to the plugin.

The new method allows to control who can access the "System Info" page.

Example usage with Spatie Laravel Permission or Filament Shield:

```php
use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;

FilamentSystemVersionsPlugin::make()
    ->authorize(fn () => auth()->user()?->hasRole('super_admin'));
```
This makes the page visible only for users who have the super_admin role.