### PR TITLE
Add Check now action to system versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ To check for outdated composer dependencies:
 php artisan dependency:versions
 ```
 
+Administrators who can access the System Versions page can also select **Check now** in the page header. The action runs the same command, prevents overlapping checks, refreshes the widgets after a successful run, and keeps the previous snapshot when the check fails.
+
 #### Automatic Scheduling
 
 Add the command to your scheduler to run it automatically:

--- a/resources/lang/en/system-versions.php
+++ b/resources/lang/en/system-versions.php
@@ -5,6 +5,20 @@ return [
         'label' => 'System Versions',
         'group' => 'Settings',
     ],
+    'actions' => [
+        'check_now' => [
+            'label' => 'Check now',
+            'modal_heading' => 'Check dependency versions now?',
+            'modal_description' => 'This contacts the configured Composer repositories and refreshes the stored dependency snapshot.',
+            'modal_submit' => 'Check now',
+            'success_title' => 'Dependency versions updated',
+            'success_body' => 'The package information on this page is now current.',
+            'already_running_title' => 'Check already running',
+            'already_running_body' => 'Another dependency version check is in progress. Try again in a few minutes.',
+            'failure_title' => 'Unable to check dependency versions',
+            'failure_body' => 'The existing snapshot was kept. Review the application logs and try again.',
+        ],
+    ],
     'widgets' => [
         'dependency' => [
             'heading' => 'Packages',

--- a/resources/lang/nl/system-versions.php
+++ b/resources/lang/nl/system-versions.php
@@ -5,6 +5,20 @@ return [
         'label' => 'Systeemversies',
         'group' => 'Instellingen',
     ],
+    'actions' => [
+        'check_now' => [
+            'label' => 'Nu controleren',
+            'modal_heading' => 'Dependencyversies nu controleren?',
+            'modal_description' => 'Hiermee worden de geconfigureerde Composer-repositories gecontroleerd en wordt de opgeslagen dependency-snapshot vernieuwd.',
+            'modal_submit' => 'Nu controleren',
+            'success_title' => 'Dependencyversies bijgewerkt',
+            'success_body' => 'De package-informatie op deze pagina is nu actueel.',
+            'already_running_title' => 'Controle wordt al uitgevoerd',
+            'already_running_body' => 'Er wordt al een dependencycontrole uitgevoerd. Probeer het over een paar minuten opnieuw.',
+            'failure_title' => 'Dependencyversies konden niet worden gecontroleerd',
+            'failure_body' => 'De bestaande snapshot is behouden. Controleer de applicatielogs en probeer het opnieuw.',
+        ],
+    ],
     'widgets' => [
         'dependency' => [
             'heading' => 'Dependencies',

--- a/src/Commands/CheckDependencyVersions.php
+++ b/src/Commands/CheckDependencyVersions.php
@@ -14,7 +14,7 @@ class CheckDependencyVersions extends Command
 
     public $description = 'Check the versions of all dependencies.';
 
-    public function handle(): void
+    public function handle(): int
     {
         // TODO: Grab all packages including up-to-date ones
         // Get the configuration values for PHP and Composer
@@ -62,14 +62,14 @@ class CheckDependencyVersions extends Command
             // Log the error but don't re-throw - just return gracefully
             $this->error('Failed to parse composer output. Check logs for details.');
 
-            return;
+            return self::FAILURE;
         }
 
         // Validate that we have the expected structure
         if (! isset($results->installed) || ! is_array($results->installed)) {
             $this->error('Invalid composer output structure. Expected "installed" array.');
 
-            return;
+            return self::FAILURE;
         }
 
         $table = config('filament-system-versions.database.table_name', 'composer_versions');
@@ -107,6 +107,8 @@ class CheckDependencyVersions extends Command
                 DB::table($table)->insert($chunk);
             }
         });
+
+        return self::SUCCESS;
     }
 
     /**

--- a/src/DependencyVersionRefreshResult.php
+++ b/src/DependencyVersionRefreshResult.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Cmsmaxinc\FilamentSystemVersions;
+
+enum DependencyVersionRefreshResult
+{
+    case Refreshed;
+    case AlreadyRunning;
+    case Failed;
+}

--- a/src/DependencyVersionRefresher.php
+++ b/src/DependencyVersionRefresher.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Cmsmaxinc\FilamentSystemVersions;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Cache;
+use RuntimeException;
+use Throwable;
+
+class DependencyVersionRefresher
+{
+    public const string LOCK_KEY = 'filament-system-versions:dependency-refresh';
+
+    public const int LOCK_SECONDS = 300;
+
+    public function __construct(private readonly Kernel $artisan) {}
+
+    public function refresh(): DependencyVersionRefreshResult
+    {
+        $lock = null;
+        $acquired = false;
+
+        try {
+            $lock = Cache::lock(self::LOCK_KEY, self::LOCK_SECONDS);
+            $acquired = $lock->get();
+
+            if (! $acquired) {
+                return DependencyVersionRefreshResult::AlreadyRunning;
+            }
+
+            $exitCode = $this->artisan->call('dependency:versions');
+
+            if ($exitCode !== Command::SUCCESS) {
+                report(new RuntimeException("The dependency:versions command exited with code {$exitCode}."));
+
+                return DependencyVersionRefreshResult::Failed;
+            }
+
+            return DependencyVersionRefreshResult::Refreshed;
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return DependencyVersionRefreshResult::Failed;
+        } finally {
+            if ($acquired && $lock instanceof Lock) {
+                $lock->release();
+            }
+        }
+    }
+}

--- a/src/Filament/Pages/SystemVersions.php
+++ b/src/Filament/Pages/SystemVersions.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Cmsmaxinc\FilamentSystemVersions\Filament\Pages;
 
 use BackedEnum;
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefresher;
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefreshResult;
 use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 use UnitEnum;
 
 class SystemVersions extends Page
 {
+    public const string DEPENDENCY_VERSIONS_REFRESHED_EVENT = 'dependency-versions-refreshed';
+
     protected string $view = 'filament-system-versions::filament.pages.system-versions';
 
     public static function canAccess(): bool
@@ -37,5 +43,63 @@ class SystemVersions extends Page
     public static function getNavigationSort(): ?int
     {
         return FilamentSystemVersionsPlugin::get()->getNavigationSort();
+    }
+
+    /** @return array<Action> */
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('checkNow')
+                ->label(__('filament-system-versions::system-versions.actions.check_now.label'))
+                ->icon('heroicon-o-arrow-path')
+                ->authorize(fn (): bool => static::canAccess())
+                ->requiresConfirmation()
+                ->modalHeading(__('filament-system-versions::system-versions.actions.check_now.modal_heading'))
+                ->modalDescription(__('filament-system-versions::system-versions.actions.check_now.modal_description'))
+                ->modalSubmitActionLabel(__('filament-system-versions::system-versions.actions.check_now.modal_submit'))
+                ->action(function (DependencyVersionRefresher $refresher): void {
+                    $this->refreshDependencyVersions($refresher);
+                }),
+        ];
+    }
+
+    protected function refreshDependencyVersions(DependencyVersionRefresher $refresher): void
+    {
+        abort_unless(static::canAccess(), 403);
+
+        match ($refresher->refresh()) {
+            DependencyVersionRefreshResult::Refreshed => $this->notifyRefreshSucceeded(),
+            DependencyVersionRefreshResult::AlreadyRunning => $this->notifyRefreshAlreadyRunning(),
+            DependencyVersionRefreshResult::Failed => $this->notifyRefreshFailed(),
+        };
+    }
+
+    private function notifyRefreshSucceeded(): void
+    {
+        $this->dispatch(self::DEPENDENCY_VERSIONS_REFRESHED_EVENT);
+
+        Notification::make()
+            ->title(__('filament-system-versions::system-versions.actions.check_now.success_title'))
+            ->body(__('filament-system-versions::system-versions.actions.check_now.success_body'))
+            ->success()
+            ->send();
+    }
+
+    private function notifyRefreshAlreadyRunning(): void
+    {
+        Notification::make()
+            ->title(__('filament-system-versions::system-versions.actions.check_now.already_running_title'))
+            ->body(__('filament-system-versions::system-versions.actions.check_now.already_running_body'))
+            ->warning()
+            ->send();
+    }
+
+    private function notifyRefreshFailed(): void
+    {
+        Notification::make()
+            ->title(__('filament-system-versions::system-versions.actions.check_now.failure_title'))
+            ->body(__('filament-system-versions::system-versions.actions.check_now.failure_body'))
+            ->danger()
+            ->send();
     }
 }

--- a/src/Filament/Widgets/DependencyWidget.php
+++ b/src/Filament/Widgets/DependencyWidget.php
@@ -2,9 +2,11 @@
 
 namespace Cmsmaxinc\FilamentSystemVersions\Filament\Widgets;
 
+use Cmsmaxinc\FilamentSystemVersions\Filament\Pages\SystemVersions;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Livewire\Attributes\On;
 
 class DependencyWidget extends Widget
 {
@@ -19,6 +21,9 @@ class DependencyWidget extends Widget
     {
         return __('filament-system-versions::system-versions.widgets.dependency.description');
     }
+
+    #[On(SystemVersions::DEPENDENCY_VERSIONS_REFRESHED_EVENT)]
+    public function refreshDependencyVersions(): void {}
 
     protected function getViewData(): array
     {

--- a/src/Filament/Widgets/SystemVersionStats.php
+++ b/src/Filament/Widgets/SystemVersionStats.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Cmsmaxinc\FilamentSystemVersions\Filament\Widgets;
 
+use Cmsmaxinc\FilamentSystemVersions\Filament\Pages\SystemVersions;
 use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Livewire\Attributes\On;
 
 class SystemVersionStats extends BaseWidget
 {
@@ -36,6 +38,9 @@ class SystemVersionStats extends BaseWidget
 
         return $stats;
     }
+
+    #[On(SystemVersions::DEPENDENCY_VERSIONS_REFRESHED_EVENT)]
+    public function refreshDependencyVersions(): void {}
 
     protected function getConfiguredPackages(): array
     {

--- a/tests/DependencyVersionRefresherTest.php
+++ b/tests/DependencyVersionRefresherTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefresher;
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefreshResult;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    config()->set('cache.default', 'array');
+    Cache::clear();
+});
+
+it('runs the existing dependency versions command', function () {
+    $artisan = Mockery::mock(Kernel::class);
+    $artisan->shouldReceive('call')
+        ->once()
+        ->with('dependency:versions')
+        ->andReturn(Command::SUCCESS);
+    app()->instance(Kernel::class, $artisan);
+
+    expect(app(DependencyVersionRefresher::class)->refresh())
+        ->toBe(DependencyVersionRefreshResult::Refreshed);
+});
+
+it('returns a failure result when the command fails', function () {
+    $artisan = Mockery::mock(Kernel::class);
+    $artisan->shouldReceive('call')
+        ->once()
+        ->with('dependency:versions')
+        ->andReturn(Command::FAILURE);
+    app()->instance(Kernel::class, $artisan);
+
+    expect(app(DependencyVersionRefresher::class)->refresh())
+        ->toBe(DependencyVersionRefreshResult::Failed);
+});
+
+it('prevents overlapping dependency checks', function () {
+    $lock = Cache::lock(
+        DependencyVersionRefresher::LOCK_KEY,
+        DependencyVersionRefresher::LOCK_SECONDS,
+    );
+
+    expect($lock->get())->toBeTrue();
+
+    try {
+        $artisan = Mockery::mock(Kernel::class);
+        $artisan->shouldReceive('call')->never();
+        app()->instance(Kernel::class, $artisan);
+
+        expect(app(DependencyVersionRefresher::class)->refresh())
+            ->toBe(DependencyVersionRefreshResult::AlreadyRunning);
+    } finally {
+        $lock->release();
+    }
+});

--- a/tests/SystemVersionsPageTest.php
+++ b/tests/SystemVersionsPageTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefresher;
+use Cmsmaxinc\FilamentSystemVersions\DependencyVersionRefreshResult;
+use Cmsmaxinc\FilamentSystemVersions\Filament\Pages\SystemVersions;
+use Cmsmaxinc\FilamentSystemVersions\Filament\Widgets\DependencyWidget;
+use Cmsmaxinc\FilamentSystemVersions\Filament\Widgets\SystemVersionStats;
+use Cmsmaxinc\FilamentSystemVersions\FilamentSystemVersionsPlugin;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Panel;
+use Livewire\Attributes\On;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class TestSystemVersionsPage extends SystemVersions
+{
+    /** @return array<Action> */
+    public function headerActions(): array
+    {
+        return $this->getHeaderActions();
+    }
+
+    public function runDependencyRefresh(DependencyVersionRefresher $refresher): void
+    {
+        $this->refreshDependencyVersions($refresher);
+    }
+}
+
+beforeEach(function () {
+    session()->forget('filament.notifications');
+
+    $this->systemVersionsPlugin = FilamentSystemVersionsPlugin::make();
+    $this->panel = Panel::make()
+        ->id('test')
+        ->plugin($this->systemVersionsPlugin);
+
+    Filament::setCurrentPanel($this->panel);
+});
+
+it('provides an authorized check now action', function () {
+    $this->systemVersionsPlugin->authorize(true);
+
+    $action = (new TestSystemVersionsPage)->headerActions()[0];
+
+    expect($action)->toBeInstanceOf(Action::class)
+        ->and($action->getName())->toBe('checkNow')
+        ->and($action->getLabel())->toBe('Check now')
+        ->and($action->isAuthorized())->toBeTrue();
+});
+
+it('notifies the administrator and refreshes the widgets after success', function () {
+    $this->systemVersionsPlugin->authorize(true);
+
+    $refresher = Mockery::mock(DependencyVersionRefresher::class);
+    $refresher->shouldReceive('refresh')
+        ->once()
+        ->andReturn(DependencyVersionRefreshResult::Refreshed);
+
+    (new TestSystemVersionsPage)->runDependencyRefresh($refresher);
+
+    Notification::assertNotified('Dependency versions updated');
+});
+
+it('shows a safe notification when the check fails', function () {
+    $this->systemVersionsPlugin->authorize(true);
+
+    $refresher = Mockery::mock(DependencyVersionRefresher::class);
+    $refresher->shouldReceive('refresh')
+        ->once()
+        ->andReturn(DependencyVersionRefreshResult::Failed);
+
+    (new TestSystemVersionsPage)->runDependencyRefresh($refresher);
+
+    Notification::assertNotified('Unable to check dependency versions');
+});
+
+it('denies the page and action to unauthorized users', function () {
+    $this->systemVersionsPlugin->authorize(false);
+
+    $page = new TestSystemVersionsPage;
+    $action = $page->headerActions()[0];
+    $refresher = Mockery::mock(DependencyVersionRefresher::class);
+    $refresher->shouldReceive('refresh')->never();
+
+    expect(SystemVersions::canAccess())->toBeFalse()
+        ->and($action->isAuthorized())->toBeFalse()
+        ->and(fn () => $page->runDependencyRefresh($refresher))
+        ->toThrow(HttpException::class);
+});
+
+it('refreshes dependency widgets after a successful check', function (string $widget) {
+    $attributes = (new ReflectionMethod($widget, 'refreshDependencyVersions'))
+        ->getAttributes(On::class);
+
+    expect($attributes)->toHaveCount(1)
+        ->and($attributes[0]->newInstance()->event)
+        ->toBe(SystemVersions::DEPENDENCY_VERSIONS_REFRESHED_EVENT);
+})->with([
+    'dependency widget' => [DependencyWidget::class],
+    'system version stats' => [SystemVersionStats::class],
+]);


### PR DESCRIPTION
## Summary

- add an authorized **Check now** header action to the System Versions page
- reuse the existing `dependency:versions` command behind a cache lock to prevent overlapping checks
- refresh both dependency widgets after a successful check and show safe success, warning, or failure notifications
- document the action and add English and Dutch translations

## Testing

- `composer format`
- `composer test` (19 tests, 43 assertions)

Closes #18