### PR TITLE
Run composer from the application root

### DIFF
--- a/src/Commands/CheckDependencyVersions.php
+++ b/src/Commands/CheckDependencyVersions.php
@@ -21,10 +21,16 @@ class CheckDependencyVersions extends Command
         $phpPath = config('filament-system-versions.paths.php_path');
         $composerPath = config('filament-system-versions.paths.composer_path');
 
+        // Composer resolves composer.json from the working directory, and a
+        // queue worker's or web server's cwd is not necessarily the app root
+        // (Laravel Cloud runs from `/` while the app lives in /var/www/html),
+        // so the process is pinned to base_path() explicitly.
+        $process = Process::path(base_path());
+
         // Check if PHP and Composer paths are set in the config, and if not, use the default approach
         if ($phpPath && $composerPath) {
             // If both PHP and Composer paths are set, run the command with the specified paths
-            $result = Process::run([
+            $result = $process->run([
                 $phpPath,
                 $composerPath,
                 'show',
@@ -33,7 +39,7 @@ class CheckDependencyVersions extends Command
             ]);
         } else {
             // If PHP or Composer path is not set, run the default Composer command
-            $result = Process::run('composer show --latest --format=json');
+            $result = $process->run('composer show --latest --format=json');
         }
 
         if ($result->failed()) {

--- a/tests/CheckDependencyVersionsTest.php
+++ b/tests/CheckDependencyVersionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    $migration = include __DIR__ . '/../database/migrations/create_composer_versions_table.php.stub';
+    $migration->up();
+});
+
+$composerOutput = json_encode([
+    'installed' => [
+        [
+            'name' => 'vendor/package',
+            'version' => '1.0.0',
+            'latest' => '1.1.0',
+            'latest-status' => 'semver-safe-update',
+            'direct-dependency' => true,
+            'description' => 'A package.',
+            'abandoned' => false,
+        ],
+    ],
+]);
+
+it('runs composer from the application root, not the inherited working directory', function () use ($composerOutput) {
+    // A queue worker's or web server's cwd is not necessarily the app root
+    // (Laravel Cloud runs from `/`), and composer resolves composer.json
+    // from cwd — the regression this pins was "No composer.json in current
+    // directory" in production.
+    Process::fake([
+        '*' => Process::result($composerOutput),
+    ]);
+
+    $this->artisan('dependency:versions')->assertSuccessful();
+
+    Process::assertRan(fn (PendingProcess $process) => $process->path === base_path());
+});
+
+it('stores the reported packages', function () use ($composerOutput) {
+    Process::fake([
+        '*' => Process::result($composerOutput),
+    ]);
+
+    $this->artisan('dependency:versions')->assertSuccessful();
+
+    expect(DB::table('composer_versions')->get())
+        ->toHaveCount(1)
+        ->sequence(fn ($row) => $row
+            ->name->toBe('vendor/package')
+            ->current_version->toBe('1.0.0')
+            ->latest_version->toBe('1.1.0')
+            ->status->toBe('semver-safe-update'));
+});


### PR DESCRIPTION
Fixes the production failure tracked in CMSMax/Max-AI-Builder#164: `Composer outdated failed: No composer.json in current directory, to use the one at /var/www/html…`.

`dependency:versions` ran `composer show --latest` in whatever working directory the calling process happened to have. Composer resolves `composer.json` from cwd, and on Laravel Cloud the web/queue process does not run from the app root — so every dependency refresh from the System Versions page failed. The process is now pinned to `base_path()` via `Process::path()` in both branches (configured php/composer paths and the default).

Two new tests fake the process and assert the working directory and the stored snapshot; the full suite (21 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)