### PR TITLE
Retry a failed composer read before alerting, and log stderr

### DIFF
--- a/src/Commands/CheckDependencyVersions.php
+++ b/src/Commands/CheckDependencyVersions.php
@@ -3,9 +3,12 @@
 namespace Cmsmaxinc\FilamentSystemVersions\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Process\ProcessResult;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
+use JsonException;
 use RuntimeException;
+use Throwable;
 use TypeError;
 
 class CheckDependencyVersions extends Command
@@ -14,58 +17,41 @@ class CheckDependencyVersions extends Command
 
     public $description = 'Check the versions of all dependencies.';
 
+    /**
+     * How much of composer's output to keep in log context, so a failure is
+     * diagnosable without writing a megabyte of JSON into the log.
+     */
+    private const OUTPUT_SAMPLE_LENGTH = 1000;
+
     public function handle(): int
     {
-        // TODO: Grab all packages including up-to-date ones
-        // Get the configuration values for PHP and Composer
-        $phpPath = config('filament-system-versions.paths.php_path');
-        $composerPath = config('filament-system-versions.paths.composer_path');
+        $result = $this->runComposerShow();
 
-        // Composer resolves composer.json from the working directory, and a
-        // queue worker's or web server's cwd is not necessarily the app root
-        // (Laravel Cloud runs from `/` while the app lives in /var/www/html),
-        // so the process is pinned to base_path() explicitly.
-        $process = Process::path(base_path());
+        [$results, $failure, $exception] = $this->decodeComposerOutput($result);
 
-        // Check if PHP and Composer paths are set in the config, and if not, use the default approach
-        if ($phpPath && $composerPath) {
-            // If both PHP and Composer paths are set, run the command with the specified paths
-            $result = $process->run([
-                $phpPath,
-                $composerPath,
-                'show',
-                '--latest',
-                '--format=json',
-            ]);
-        } else {
-            // If PHP or Composer path is not set, run the default Composer command
-            $result = $process->run('composer show --latest --format=json');
+        // `composer show --latest` reaches out to Packagist and to any private
+        // repositories the app uses, so a momentary network or auth blip can
+        // produce exit code 0 with unusable output. Retry once before treating
+        // that as a real problem: otherwise a single blip raises an alert for a
+        // nightly command that would have healed itself on the next run.
+        if ($results === null) {
+            logger()->warning(
+                'Composer output could not be parsed, retrying once. ' . $failure,
+                $this->failureContext($result)
+            );
+
+            $result = $this->runComposerShow();
+
+            [$results, $failure, $exception] = $this->decodeComposerOutput($result);
         }
 
-        if ($result->failed()) {
-            throw new RuntimeException('Composer outdated failed: ' . $result->errorOutput());
-        }
+        if ($results === null) {
+            logger()->error($failure, $this->failureContext($result) + ['exception' => $exception]);
 
-        $output = $this->cleanJsonOutput($result->output());
+            // Only report once the retry has also failed, so an alert means
+            // "this is persistently broken" rather than "the network hiccuped".
+            report(new \Exception($failure . ' See logs for details.', 0, $exception));
 
-        try {
-            $results = json_decode($output, flags: JSON_THROW_ON_ERROR);
-        } catch (\JsonException | TypeError $e) {
-            // Get a sample of the output (first 1000 chars) to avoid huge log entries
-            $sampleOutput = substr($output, 0, 1000) . (strlen($output) > 1000 ? '...(truncated)' : '');
-
-            $errorMessage = 'JSON decode failed: ' . $e->getMessage();
-            logger()->error($errorMessage, [
-                'output_sample' => $sampleOutput,
-                'output_length' => strlen($output),
-                'original_output_length' => strlen($result->output()),
-                'exception' => $e,
-            ]);
-
-            // Report to error tracking (Nightwatch) and continue gracefully
-            report(new \Exception($errorMessage . ' See logs for details.', 0, $e));
-
-            // Log the error but don't re-throw - just return gracefully
             $this->error('Failed to parse composer output. Check logs for details.');
 
             return self::FAILURE;
@@ -115,6 +101,94 @@ class CheckDependencyVersions extends Command
         });
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Run `composer show --latest --format=json` against the application root.
+     */
+    private function runComposerShow(): ProcessResult
+    {
+        // Get the configuration values for PHP and Composer
+        $phpPath = config('filament-system-versions.paths.php_path');
+        $composerPath = config('filament-system-versions.paths.composer_path');
+
+        // Composer resolves composer.json from the working directory, and a
+        // queue worker's or web server's cwd is not necessarily the app root
+        // (Laravel Cloud runs from `/` while the app lives in /var/www/html),
+        // so the process is pinned to base_path() explicitly.
+        $process = Process::path(base_path());
+
+        // Check if PHP and Composer paths are set in the config, and if not, use the default approach
+        if ($phpPath && $composerPath) {
+            // If both PHP and Composer paths are set, run the command with the specified paths
+            $result = $process->run([
+                $phpPath,
+                $composerPath,
+                'show',
+                '--latest',
+                '--format=json',
+            ]);
+        } else {
+            // If PHP or Composer path is not set, run the default Composer command
+            $result = $process->run('composer show --latest --format=json');
+        }
+
+        if ($result->failed()) {
+            throw new RuntimeException('Composer outdated failed: ' . $result->errorOutput());
+        }
+
+        return $result;
+    }
+
+    /**
+     * Decode composer's JSON output.
+     *
+     * @return array{0: ?object, 1: ?string, 2: ?Throwable} the decoded payload, or null
+     *                                                      plus a description of why it could not be decoded
+     */
+    private function decodeComposerOutput(ProcessResult $result): array
+    {
+        $output = $this->cleanJsonOutput($result->output());
+
+        // Composer exiting 0 with nothing on stdout decodes as a bare "Syntax
+        // error", which reads as malformed JSON and sends you looking for the
+        // wrong thing. Name it for what it actually is instead.
+        if ($output === '') {
+            return [null, 'Composer produced no output to parse.', null];
+        }
+
+        try {
+            return [json_decode($output, flags: JSON_THROW_ON_ERROR), null, null];
+        } catch (JsonException | TypeError $e) {
+            return [null, 'JSON decode failed: ' . $e->getMessage(), $e];
+        }
+    }
+
+    /**
+     * Context describing a failed composer run.
+     *
+     * Includes stderr: composer writes warnings and network/auth errors there,
+     * so when stdout is empty or truncated it is the only thing that explains
+     * why — and it was the piece missing when this last failed in production.
+     *
+     * @return array<string, mixed>
+     */
+    private function failureContext(ProcessResult $result): array
+    {
+        $output = $this->cleanJsonOutput($result->output());
+
+        return [
+            'output_sample' => $this->sample($output),
+            'output_length' => strlen($output),
+            'original_output_length' => strlen($result->output()),
+            'error_output' => $this->sample($result->errorOutput()),
+        ];
+    }
+
+    private function sample(string $value): string
+    {
+        return substr($value, 0, self::OUTPUT_SAMPLE_LENGTH)
+            . (strlen($value) > self::OUTPUT_SAMPLE_LENGTH ? '...(truncated)' : '');
     }
 
     /**

--- a/tests/CheckDependencyVersionsTest.php
+++ b/tests/CheckDependencyVersionsTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Process\PendingProcess;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 
 beforeEach(function () {
@@ -52,3 +53,78 @@ it('stores the reported packages', function () use ($composerOutput) {
             ->latest_version->toBe('1.1.0')
             ->status->toBe('semver-safe-update'));
 });
+
+it('retries once when composer returns unparseable output, then succeeds', function () use ($composerOutput) {
+    // `composer show --latest` hits Packagist and any private repositories, so a
+    // momentary blip can exit 0 with unusable output. That should self-heal
+    // rather than raise an alert.
+    Process::fake([
+        '*' => Process::sequence()
+            ->push(Process::result('not json at all'))
+            ->push(Process::result($composerOutput)),
+    ]);
+
+    $this->artisan('dependency:versions')->assertSuccessful();
+
+    expect(DB::table('composer_versions')->get())->toHaveCount(1);
+});
+
+it('fails only after the retry also returns unparseable output', function () {
+    Process::fake([
+        '*' => Process::result('not json at all'),
+    ]);
+
+    $this->artisan('dependency:versions')->assertFailed();
+
+    // Twice, not once: the retry is what keeps a single blip from alerting.
+    Process::assertRanTimes(fn (PendingProcess $process) => $process->path === base_path(), 2);
+
+    expect(DB::table('composer_versions')->get())->toBeEmpty();
+});
+
+it('reports empty composer output as such rather than as a JSON syntax error', function () {
+    // Exit code 0 with nothing on stdout used to surface as a bare
+    // "JSON decode failed: Syntax error", which points at the wrong problem.
+    Log::spy();
+
+    Process::fake([
+        '*' => Process::result(''),
+    ]);
+
+    $this->artisan('dependency:versions')->assertFailed();
+
+    Log::shouldHaveReceived('error')
+        ->withArgs(fn (...$args) => str_contains($args[0], 'Composer produced no output'));
+});
+
+it('keeps the previous snapshot when composer output cannot be parsed', function () {
+    DB::table('composer_versions')->insert([
+        'name' => 'vendor/previous',
+        'current_version' => '1.0.0',
+        'latest_version' => '1.0.0',
+        'status' => 'up-to-date',
+        'direct_dependency' => true,
+        'description' => 'Kept from the last good run.',
+        'abandoned' => false,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    Process::fake([
+        '*' => Process::result('not json at all'),
+    ]);
+
+    $this->artisan('dependency:versions')->assertFailed();
+
+    expect(DB::table('composer_versions')->get())
+        ->toHaveCount(1)
+        ->sequence(fn ($row) => $row->name->toBe('vendor/previous'));
+});
+
+it('throws when composer itself fails', function () {
+    Process::fake([
+        '*' => Process::result(output: '', errorOutput: 'Could not authenticate', exitCode: 1),
+    ]);
+
+    $this->artisan('dependency:versions');
+})->throws(RuntimeException::class, 'Composer outdated failed: Could not authenticate');


### PR DESCRIPTION
## What prompted this

A production Nightwatch alert on the nightly `dependency:versions` run:

> `Exception: JSON decode failed: Syntax error See logs for details.`
> `CheckDependencyVersions.php:66` — 1 occurrence in 30 days, 0 users affected

Line 66 is the `report(...)` call itself, so the alert is this command deliberately reporting a failure it had already handled. The command caught the error, logged it, printed a message and returned — nothing crashed, and the next night's run recovered on its own.

Two things made that alert unhelpful rather than useful:

1. **It fires on the first failure.** `composer show --latest` reaches out to Packagist *and* to any private repositories the consuming app uses. A momentary network or auth blip there produces exit code 0 with unusable stdout. For a nightly command that self-heals, one blip should not page anyone.
2. **It could not be diagnosed.** The log context captured a sample of *stdout* and its length — but not **stderr**, which is where composer writes warnings and network/auth errors. When stdout is empty or truncated, stderr is the only thing that explains why. Working the production occurrence back from the logs was not possible for exactly this reason.

Worth noting this occurred **after** #20 (run composer from the application root) shipped — the line number in the trace matches post-#20 `main`, not the previous release — so the working-directory fix was already in place and this is a different cause.

## What changed

- **Retry the composer read once before reporting.** Persistent breakage still alerts; a single blip no longer does. The retry only runs on the failure path, so the success path costs nothing.
- **Log composer's stderr on failure**, alongside the existing stdout sample and lengths.
- **Name empty output for what it is.** Exit code 0 with nothing on stdout decoded as a bare `JSON decode failed: Syntax error`, which reads as malformed JSON and sends you looking for the wrong thing. It now says `Composer produced no output to parse.`

The composer invocation and the JSON decode moved into private methods so the retry doesn't duplicate them. **Behaviour on the success path is unchanged**, as is the `RuntimeException` when composer itself exits non-zero.

## What this does *not* claim

This does not identify the root cause of the production occurrence — that is still unknown, and deliberately so: the honest fix is to stop alerting on a self-healing blip and to capture the evidence needed to diagnose the next one, rather than to guess at a cause and silence the symptom. If it recurs, `error_output` in the log context should say why.

## Tests

Five added to `tests/CheckDependencyVersionsTest.php`. Three of them fail against `main` and pass here (verified by stashing the source change and re-running):

- retries once when composer returns unparseable output, then succeeds
- fails only after the retry also returns unparseable output — asserts composer actually ran **twice**
- reports empty composer output as such rather than as a JSON syntax error — asserts the logged message, not just that it failed

Two are characterisation tests that pass on `main` too, documenting behaviour worth keeping pinned:

- keeps the previous snapshot when composer output cannot be parsed
- throws when composer itself fails

Full suite: **26 passed (63 assertions)**. Pint clean.

> Note: Pint on this Windows clone wants to rewrite every file's line endings (CRLF artifact of `gh repo clone`), so I ran it scoped to the two files I touched. The diff is those two files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)